### PR TITLE
fix: fixes 2fa verify challenge and unrollment

### DIFF
--- a/src/app/authMFA/page.js
+++ b/src/app/authMFA/page.js
@@ -1,0 +1,61 @@
+"use client";
+import { useState } from "react";
+import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+
+function AuthMFA() {
+  const [verifyCode, setVerifyCode] = useState("");
+  const [error, setError] = useState("");
+
+  const supabase = createClientComponentClient();
+
+  const onSubmitClicked = () => {
+    setError("");
+    (async () => {
+      const factors = await supabase.auth.mfa.listFactors();
+      if (factors.error) {
+        throw factors.error;
+      }
+
+      const totpFactor = factors.data.totp[0];
+
+      if (!totpFactor) {
+        throw new Error("No TOTP factors found!");
+      }
+
+      const factorId = totpFactor.id;
+
+      const challenge = await supabase.auth.mfa.challenge({ factorId });
+      if (challenge.error) {
+        setError(challenge.error.message);
+        throw challenge.error;
+      }
+
+      const challengeId = challenge.data.id;
+
+      const verify = await supabase.auth.mfa.verify({
+        factorId,
+        challengeId,
+        code: verifyCode,
+      });
+      if (verify.error) {
+        setError(verify.error.message);
+        throw verify.error;
+      }
+    })();
+  };
+
+  return (
+    <>
+      <div>Please enter the code from your authenticator app.</div>
+      {error && <div className="error">{error}</div>}
+      <input
+        type="text"
+        value={verifyCode}
+        onChange={(e) => setVerifyCode(e.target.value.trim())}
+      />
+      <input type="button" value="Submit" onClick={onSubmitClicked} />
+    </>
+  );
+}
+
+export default AuthMFA;

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import { useEffect, useState } from "react";
+import Layout from "@/components/page-layout";
 
 export default function Home() {
   const router = useRouter();
@@ -33,7 +34,7 @@ export default function Home() {
     }
   };
   return (
-    <>
+    <Layout>
       {user ? (
         <div className="flex flex-col gap-6 items-center justify-center min-h-screen">
           <h2 className="text-2xl">You are signed in</h2>
@@ -57,6 +58,6 @@ export default function Home() {
           <h2 className="text-2xl">You are not authorized to view this page</h2>
         </div>
       )}
-    </>
+    </Layout>
   );
 }

--- a/src/app/profile/page.js
+++ b/src/app/profile/page.js
@@ -1,5 +1,11 @@
+"use client";
+import Layout from "@/components/page-layout";
 import ProfileComp from "@/components/profile/page";
 
 export default function Profile() {
-  return <ProfileComp />;
+  return (
+    <Layout>
+      <ProfileComp />;
+    </Layout>
+  );
 }

--- a/src/components/page-layout/index.js
+++ b/src/components/page-layout/index.js
@@ -1,0 +1,45 @@
+"use client";
+import {} from "next/client";
+import { useEffect, useState } from "react";
+import { redirect } from "next/navigation";
+import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+
+function Layout({ children }) {
+  const [readyToShow, setReadyToShow] = useState(false);
+  const [showMFAScreen, setShowMFAScreen] = useState(false);
+
+  const supabase = createClientComponentClient();
+
+  useEffect(() => {
+    async function checkAuthentication() {
+      try {
+        const { data, error } =
+          await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
+        if (error) {
+          throw error;
+        }
+
+        if (data.nextLevel === "aal2" && data.nextLevel !== data.currentLevel) {
+          setShowMFAScreen(true);
+        }
+      } catch (error) {
+        console.error("Error checking authentication:", error.message);
+      } finally {
+        setReadyToShow(true);
+      }
+    }
+
+    checkAuthentication();
+  }, []);
+
+  useEffect(() => {
+    // Redirect to MFA setup page if necessary
+    if (readyToShow && showMFAScreen) {
+      redirect("/authMFA"); // Replace '/authMFA' with your actual MFA setup route
+    }
+  }, [readyToShow, showMFAScreen]);
+
+  return readyToShow ? <>{children}</> : null;
+}
+
+export default Layout;

--- a/src/components/signInComp/page.jsx
+++ b/src/components/signInComp/page.jsx
@@ -62,13 +62,7 @@ function SignInComp() {
         if (factors.totp.length > 0) {
           // MFA is enabled, prompt for verification code
           setIsLoading(true); // Show loading state while waiting for MFA input
-          openModal();
-          setIsLoading(false); // Hide loading state once MFA input is received
-          if (totpVerified) {
-            // MFA code is verified, proceed with login
-            closeModal();
-            router.push("/");
-          }
+          router.push("/authMFA");
         } else {
           // MFA is not enabled, proceed with login
           router.push("/");


### PR DESCRIPTION
# Pull Request

## Description

From the video you sent there were mentioned two main problems:
- users bypassing 2fa challenge step
- users not being able to delete their factor

we pretty much killed two birds with one stone because users were not able to delete their configured factor because they kept bypassing the 2fa challenge step. User can delete a factor only if he is AAL2 (ie: went through the conventional login + one additional verification step of the 2fa), which he wasn't, he kept only the AAl1 level of authentication. 

So for that you we were missing a big part, which is wrapping the whole app and checking if the user has AAL2 or not, and that can not be done from a static modal, because it's not a one time thing that the user must do immediately after sign up but rather a new level of authentication for the whole app. So I created a layout component that needs to wrap every auth protected page! 

I copy pasted a lot of code, since this is only a playground either way, but what you can do is replace the /authMFA page content with just rendering the `challengeMFA` component. 

And one more thing, I used the "use client" fix left and right whenever I encountered the error conflict between the server and client side component, so this is left for you to later fix it in the real app. 

Note: it seems like the build is failing, but I can only check that after you can give me some insights about it since I don't have permission. 

p.s as for the modal not closing after a newly added factor and needing to be refreshed I can check that in a new PR, but if you want to take it feel free, as I think it only involves adding a new property to the `enrollMFA` component, which will be a function that is called when the user enables that as a factor, then in `profile` component, we create a function that gets a factor ID and sets it in the state, we then pass that function to `enrollMFA`.